### PR TITLE
Fix: corrected published date format in index.qmd (ISO 8601)

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -2,7 +2,7 @@
 title: "How to Start Your Own Code Club"
 author: "Cecilia Baldoni, Saoirse Kelleher, Natalie van Dis, Corné de Groot"
 event: SORTEE Conference 2025 — Unconference Session 5
-date: 16/10/2025
+date: 2025-10-16
 format: 
   html:
     self-contained: true


### PR DESCRIPTION
This is a small correction:

Published date format in `index.qmd`

The date was not in ISO 8601 format (YYYY-MM-DD).

I updated it for consistency and clarity.  

Thank you. 